### PR TITLE
Added MnemonicQR, ExportMnemonicDataSchema and encoders

### DIFF
--- a/examples/Example.ts
+++ b/examples/Example.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+
+export abstract class Example {
+    /**
+     * Construct an example instance
+     *
+     */
+    constructor() {}
+
+    /// region Abstract Methods
+    /**
+     * The `execute()` method should run the underlying
+     * example business flow.
+     *
+     * @return {number}
+     */
+    public abstract execute(): number;
+    /// end-region Abstract Methods
+}

--- a/examples/Example.ts
+++ b/examples/Example.ts
@@ -28,6 +28,24 @@ export abstract class Example {
      *
      * @return {number}
      */
-    public abstract execute(): number;
+    public abstract async execute(): Promise<number>;
     /// end-region Abstract Methods
+
+    /**
+     * 
+     */
+    public resolve<T>(resp: T): Promise<T> {
+        return new Promise((resolve, reject) => {
+            return resolve(resp);
+        });
+    }
+
+    /**
+     * 
+     */
+    public reject<T>(resp: T): Promise<T> {
+        return new Promise((resolve, reject) => {
+            return reject(resp);
+        });
+    }
 }

--- a/examples/ExampleAddContactQR.ts
+++ b/examples/ExampleAddContactQR.ts
@@ -22,20 +22,34 @@ import {
     ContactQR,
     QRCodeType,
 } from '../index';
+import {Example} from './Example';
 
-// Arrange
-const contactInfo = {
-    v: 3,
-    type: QRCodeType.AddContact,
-    network_id: NetworkType.MIJIN_TEST,
-    chain_id: 'no-chain-id',
-    data: {
-        name: 'nemtech',
-        address: 'SDUFICQAIHN2VYORJILRQ5YXAERLJF5HDTPJNXVR'
+export class ExampleAddContactQR extends Example {
+
+    /**
+     * The `execute()` method should run the underlying
+     * example business flow.
+     *
+     * @return {number}
+     */
+    public execute(): number {
+
+        // Arrange
+        const contactInfo = {
+            v: 3,
+            type: QRCodeType.AddContact,
+            network_id: NetworkType.MIJIN_TEST,
+            chain_id: 'no-chain-id',
+            data: {
+                name: 'nemtech',
+                publicKey: 'D90ABF5BADC4E709E79E8F168F1629CD90D7F5B41010B7C0616C2121D516C11C'
+            }
+        };
+
+        // create QR Code with JSON content
+        const contactQR = ContactQR.fromJSON(JSON.stringify(contactInfo));
+        console.log(contactQR.toASCII());
+        return 0;
     }
-};
+}
 
-// create QR Code with JSON content
-const contactQR = ContactQR.fromJSON(JSON.stringify(contactInfo));
-
-console.log(contactQR.toASCII());

--- a/examples/ExampleAddContactQR.ts
+++ b/examples/ExampleAddContactQR.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    NetworkType,
+} from 'nem2-sdk';
+
+// internal dependencies
+import {
+    ContactQR,
+    QRCodeType,
+} from '../index';
+
+// Arrange
+const contactInfo = {
+    v: 3,
+    type: QRCodeType.AddContact,
+    network_id: NetworkType.MIJIN_TEST,
+    chain_id: 'no-chain-id',
+    data: {
+        name: 'nemtech',
+        address: 'SDUFICQAIHN2VYORJILRQ5YXAERLJF5HDTPJNXVR'
+    }
+};
+
+// create QR Code with JSON content
+const contactQR = ContactQR.fromJSON(JSON.stringify(contactInfo));
+
+console.log(contactQR.toASCII());

--- a/examples/ExampleExportAccountQR.ts
+++ b/examples/ExampleExportAccountQR.ts
@@ -15,16 +15,18 @@
  */
 import {
     NetworkType,
+    Account,
+    Password,
 } from 'nem2-sdk';
 
 // internal dependencies
 import {
-    ContactQR,
+    AccountQR,
     QRCodeType,
 } from '../index';
 import {Example} from './Example';
 
-export class ExampleAddContactQR extends Example {
+export class ExampleExportAccountQR extends Example {
 
     /**
      * The `execute()` method should run the underlying
@@ -35,24 +37,28 @@ export class ExampleAddContactQR extends Example {
     public async execute(): Promise<number> {
 
         // Arrange
-        const contactInfo = {
+        const accountInfo = {
             v: 3,
-            type: QRCodeType.AddContact,
-            network_id: NetworkType.MIJIN_TEST,
-            chain_id: 'no-chain-id',
+            type: 2,
+            network_id: 144,
+            chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
             data: {
-                name: 'nemtech',
-                publicKey: 'D90ABF5BADC4E709E79E8F168F1629CD90D7F5B41010B7C0616C2121D516C11C'
+                ciphertext: 'cdc2f1ff390dd21b4528f5b75e69b30aNkYsuMlvsC7bShwqilk8P0txdWiQptMNypbjV9p5VFw766YIGqOfm336U1mMrMGwbPeIqbuPXsc8+stuGJ/M0OswzzDJ9BZyDQ+UK7sYBwE=',
+                salt: '9860f8643b3b1d77514a63eb4cbc0d9dbd6091bca10e742663d2bcc6b79fe7fb'
             }
         };
 
-        // create QR Code with JSON content
-        const contactQR = ContactQR.fromJSON(JSON.stringify(contactInfo));
-        console.log("JSON: ", contactQR.toJSON());
-        console.log("BASE64: ", contactQR.toBase64());
+        // create QR Code with JSON content and password
+        const accountQR = AccountQR.fromJSON(
+            JSON.stringify(accountInfo),
+            new Password('Intranet123')
+        );
+
+        console.log("JSON: ", accountQR.toJSON());
+        console.log("BASE64: ", accountQR.toBase64());
         console.log("");
         console.log("ASCII: ");
-        console.log(contactQR.toASCII());
+        console.log(accountQR.toASCII());
         console.log("");
         return this.resolve(0);
     }

--- a/examples/ExampleExportMnemonicQR.ts
+++ b/examples/ExampleExportMnemonicQR.ts
@@ -18,53 +18,55 @@ import {
     Account,
     Password,
 } from 'nem2-sdk';
+import {MnemonicPassPhrase} from 'nem2-hd-wallets';
 
 // internal dependencies
 import {
-    AccountQR,
+    MnemonicQR,
     QRCodeType,
 } from '../index';
 import {Example} from './Example';
 
-export class ExampleExportAccountQR extends Example {
+export class ExampleExportMnemonicQR extends Example {
 
     /**
      * The `execute()` method should run the underlying
      * example business flow.
      *
      * This example uses an encryption password value of `password`
-     * and following account details
+     * and following 24-words mnemonic pass phrase:
      * 
-     *    Public Key: 9741183860ED711BD986A464004DB9A6D26B25F4CBB51F3B0FF1B220510B86B0
-     *    Private Key: 749F1FF1972CD465CAB74566FF0AA021F846FBE3916ABB6A6C1373E962C76331
+     *    stumble shoot spawn bitter forest waste attitude chest
+     *    square kite dawn photo twice message bargain trap
+     *    spin vote lamp wire also either else pupil
      *
      * @return {number}
      */
     public async execute(): Promise<number> {
 
-        // Arrange
-        const accountInfo = {
+        // MnemonicQR example data
+        const mnemonicInfo = {
             v: 3,
-            type: QRCodeType.ExportAccount,
+            type: QRCodeType.ExportMnemonic,
             network_id: NetworkType.MIJIN_TEST,
-            chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+            chain_id: "9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7",
             data: {
-                ciphertext: '56d310848ee93d0794eb1f64a5195778ded2q7IxvtPbO+sA7jZZyhpu/khbaNdx1pzuoGoPJRw1A4aBsWPlex3y/gy5da8WjF0i4d+/D0B5ESy+zX5P+AoFAw3EFi3UVBdnav4rnqg=',
-                salt: '42c8615bc6b2bc88cd239f08a5a17cc62bb0ebaece53f3e458a1cd67cd0888bc'
+                ciphertext: "964322228f401a2ec576ac256cbbdce29YfW+CykqESzGSzDYuKJxJUSpQ4woqMdD8Up7mjbow09I/UYV4e8HEgbhjlLjf30YLlQ+JKLBTf9kUGMnp3tZqYSq3lLZRDp8TVE6GzHiX4V59RTP7BOixwpDWDmfOP0B0i+Q1s0+OPfmyck4p7YZkVNi/HYvQF4kDV27sjRTZKs+uETKA0Ae0rl17d9EMV3eLUVcWEGE/ChgEfmnMlN1g==",
+                salt: "b248953e9ebfa269cd7b940f9c03d2d4b192f90db61638375b5e78296bbe675a"
             }
         };
 
         // create QR Code with JSON content and password
-        const accountQR = AccountQR.fromJSON(
-            JSON.stringify(accountInfo),
+        const mnemonicQR = MnemonicQR.fromJSON(
+            JSON.stringify(mnemonicInfo),
             new Password('password')
         );
 
-        console.log("JSON: ", accountQR.toJSON());
-        console.log("BASE64: ", accountQR.toBase64());
+        console.log("JSON: ", mnemonicQR.toJSON());
+        console.log("BASE64: ", mnemonicQR.toBase64());
         console.log("");
         console.log("ASCII: ");
-        console.log(accountQR.toASCII());
+        console.log(mnemonicQR.toASCII());
         console.log("");
         return this.resolve(0);
     }

--- a/examples/ExampleRequestTransactionQR.ts
+++ b/examples/ExampleRequestTransactionQR.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    NetworkType,
+    Account,
+    TransferTransaction,
+    Deadline,
+    EmptyMessage,
+    Mosaic,
+    NamespaceId,
+    UInt64,
+} from 'nem2-sdk';
+import {MnemonicPassPhrase} from 'nem2-hd-wallets';
+
+// internal dependencies
+import {
+    TransactionQR,
+    QRCodeType,
+} from '../index';
+import {Example} from './Example';
+
+export class ExampleRequestTransactionQR extends Example {
+
+    /**
+     * The `execute()` method should run the underlying
+     * example business flow.
+     *
+     * This example uses an unsigned transfer transaction
+     * with following details:
+     *    - Recipient: namespaceId "nemtech"
+     *    - Mosaics: 1 mosaic with namespaceId "cat.currency" and absolute amount 1
+     *    - Message: Empty
+     *
+     * @return {number}
+     */
+    public async execute(): Promise<number> {
+
+        const unsignedTransferInfo = {
+            v: 3,
+            type: 3,
+            network_id: NetworkType.MIJIN_TEST,
+            chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+            data: {
+                payload: 'A500000000000000000000000000000000000000000000000000000000000000'
+                       + '0000000000000000000000000000000000000000000000000000000000000000'
+                       + '0000000000000000000000000000000000000000000000000000000000000000'
+                       + '000000000190544100000000000000008CDC693819000000912C7BC6007CB8AC'
+                       + 'B8000000000000000000000000000000000100010044B262C46CEABB85010000'
+                       + '0000000000'
+            }
+        };
+
+        // create QR Code with JSON content
+        const transactionQR = TransactionQR.fromJSON(
+            JSON.stringify(unsignedTransferInfo),
+        );
+
+        console.log("JSON: ", transactionQR.toJSON());
+        console.log("BASE64: ", transactionQR.toBase64());
+        console.log("");
+        console.log("ASCII: ");
+        console.log(transactionQR.toASCII());
+        console.log("");
+        return this.resolve(0);
+    }
+}
+

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>Example for nem2-qr-library</title>
+        <meta name="description" content="Browser Examples for nem2-qr-library">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <script>var exports = {};</script>
+        <script src="../dist/index.js"></script>
+    </head>
+
+    <body>
+<script>
+// ContactQR created from JSON
+const contactInfo = {
+    v: 3,
+    type: QRCodeType.AddContact,
+    network_id: NetworkType.MIJIN_TEST,
+    chain_id: 'no-chain-id',
+    data: {
+        name: 'nemtech',
+        publicKey: 'D90ABF5BADC4E709E79E8F168F1629CD90D7F5B41010B7C0616C2121D516C11C'
+    }
+};
+const contactQR = ContactQR.fromJSON(JSON.stringify(contactInfo));
+
+// AccountQR created from JSON
+const accountInfo = {
+    v: 3,
+    type: 2,
+    network_id: 144,
+    chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+    data: {
+        ciphertext: 'cdc2f1ff390dd21b4528f5b75e69b30aNkYsuMlvsC7bShwqilk8P0txdWiQptMNypbjV9p5VFw766YIGqOfm336U1mMrMGwbPeIqbuPXsc8+stuGJ/M0OswzzDJ9BZyDQ+UK7sYBwE=',
+        salt: '9860f8643b3b1d77514a63eb4cbc0d9dbd6091bca10e742663d2bcc6b79fe7fb'
+    }
+};
+
+// create QR Code with JSON content and password
+const accountQR = AccountQR.fromJSON(
+    JSON.stringify(accountInfo),
+    new Password('Intranet123')
+);
+
+// Updagte DOM
+
+let dom = document;
+let qr1_1 = dom.getElementById("qr-code-1-1");
+let qr1_2 = dom.getElementById("qr-code-1-2");
+
+qr1_1.setAttribute('src', contactQR.toBase64());
+qr1_2.setAttribute('src', accountQR.toBase64());
+</script>
+
+        <div id="examples-wrapper">
+            <div class="example" rel="1">
+                <img src=""
+                     width="500px"
+                     height="500px"
+                     id="qr-code-1-1" />
+
+                    
+                <img src=""
+                    width="500px"
+                    height="500px"
+                    id="qr-code-1-2" />
+            </div>
+        </div>
+	</body>
+</html>

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    NetworkType,
+} from 'nem2-sdk';
+
+// internal dependencies
+import {Example} from './Example';
+import {ExampleAddContactQR} from './ExampleAddContactQR';
+
+console.log("Starting examples");
+
+// EX 1: Contact QR Code example
+const contactQR = new ExampleAddContactQR();
+contactQR.execute();

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -20,9 +20,27 @@ import {
 // internal dependencies
 import {Example} from './Example';
 import {ExampleAddContactQR} from './ExampleAddContactQR';
+import {ExampleExportAccountQR} from './ExampleExportAccountQR';
 
-console.log("Starting examples");
+console.log("Starting examples for nem2-qr-library");
+console.log("");
 
+// -----------------------------
 // EX 1: Contact QR Code example
+// -----------------------------
+console.log("1) Creating Contact QR-Code");
+console.log("");
+
 const contactQR = new ExampleAddContactQR();
 contactQR.execute();
+console.log("");
+
+// -----------------------------
+// EX 2: Account QR Code example
+// -----------------------------
+console.log("2) Creating Account QR-Code");
+console.log("");
+
+const accountQR = new ExampleExportAccountQR();
+accountQR.execute();
+console.log("");

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -21,6 +21,8 @@ import {
 import {Example} from './Example';
 import {ExampleAddContactQR} from './ExampleAddContactQR';
 import {ExampleExportAccountQR} from './ExampleExportAccountQR';
+import {ExampleExportMnemonicQR} from './ExampleExportMnemonicQR';
+import {ExampleRequestTransactionQR} from './ExampleRequestTransactionQR';
 
 console.log("Starting examples for nem2-qr-library");
 console.log("");
@@ -43,4 +45,24 @@ console.log("");
 
 const accountQR = new ExampleExportAccountQR();
 accountQR.execute();
+console.log("");
+
+// -----------------------------
+// EX 3: Mnemonic QR Code example
+// -----------------------------
+console.log("3) Creating Mnemonic QR-Code");
+console.log("");
+
+const mnemonicQR = new ExampleExportMnemonicQR();
+mnemonicQR.execute();
+console.log("");
+
+// -----------------------------
+// EX 4: Transaction QR Code example
+// -----------------------------
+console.log("3) Creating Transaction Request QR-Code");
+console.log("");
+
+const transactionQR = new ExampleRequestTransactionQR();
+transactionQR.execute();
 console.log("");

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,13 @@
 export { QRCodeType } from './src/QRCodeType';
 export { QRCodeSettings } from './src/QRCodeSettings';
 export { QRCodeInterface } from './src/QRCodeInterface';
+
+// encoder classes
+export { EncoderInterface } from './src/encoders/EncoderInterface';
+export { EncoderMinimalASCII } from './src/encoders/EncoderMinimalASCII';
+export { EncoderASCII } from './src/encoders/EncoderASCII';
+
+// abstract QRCode
 export { QRCode } from './src/QRCode';
 
 // QR Code data schemas

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ export { QRCode } from './src/QRCode';
 export { QRCodeDataSchema } from './src/QRCodeDataSchema';
 export { AddContactDataSchema } from './src/schemas/AddContactDataSchema';
 export { ExportAccountDataSchema } from './src/schemas/ExportAccountDataSchema';
+export { ExportMnemonicDataSchema } from './src/schemas/ExportMnemonicDataSchema';
 export { ExportObjectDataSchema } from './src/schemas/ExportObjectDataSchema';
 export { RequestTransactionDataSchema } from './src/schemas/RequestTransactionDataSchema';
 export { RequestCosignatureDataSchema } from './src/schemas/RequestCosignatureDataSchema';
@@ -45,6 +46,7 @@ export { ContactQR } from './src/ContactQR';
 export { ObjectQR } from './src/ObjectQR';
 export { TransactionQR } from './src/TransactionQR';
 export { CosignatureQR } from './src/CosignatureQR';
+export { MnemonicQR } from './src/MnemonicQR';
 
 // factory
 export { QRCodeGenerator } from './src/QRCodeGenerator';

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,10 +141,24 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.12.tgz",
-      "integrity": "sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
+      "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ==",
       "dev": true
+    },
+    "@types/qrcode": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.3.3.tgz",
+      "integrity": "sha512-+5vox9KhEPGP+d2ah8V+gnHAaTDvFHssLz8KJS7OgJuessGGybChJYfmo+fwNFzOVUtfcWkTCJqkFDRz15hCYw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "12.6.1"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -190,7 +204,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "1.9.3"
       }
@@ -204,11 +217,25 @@
         "default-require-extensions": "2.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -290,8 +317,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "batch": {
       "version": "0.6.1",
@@ -312,39 +338,31 @@
       "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "1.0.4",
         "debug": "2.6.9",
         "depd": "1.1.2",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
         "type-is": "1.6.18"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -352,7 +370,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -400,8 +417,17 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "canvas": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.0.tgz",
+      "integrity": "sha512-bEO9f1ThmbknLPxCa8Es7obPlN9W3stB1bo7njlhOFKIdUTldeTqXCh9YclCPAi2pSQs84XA0jq/QEZXSzgyMw==",
+      "requires": {
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.11.0",
+        "simple-get": "3.0.3"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -439,6 +465,11 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -449,7 +480,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "requires": {
         "string-width": "3.1.0",
         "strip-ansi": "5.2.0",
@@ -459,20 +489,17 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "7.0.3",
             "is-fullwidth-code-point": "2.0.0",
@@ -483,18 +510,21 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "4.1.0"
           }
         }
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -502,8 +532,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -552,38 +581,30 @@
         "on-headers": "1.0.2",
         "safe-buffer": "5.1.2",
         "vary": "1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "content-type": {
       "version": "1.0.4",
@@ -600,9 +621,9 @@
       }
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -665,18 +686,32 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
-        "ms": "2.1.1"
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -686,6 +721,11 @@
       "requires": {
         "type-detect": "4.0.8"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -701,6 +741,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -711,11 +756,21 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "dijkstrajs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
+      "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -734,8 +789,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -746,7 +800,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -819,7 +872,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
       "requires": {
         "cross-spawn": "6.0.5",
         "get-stream": "4.1.0",
@@ -834,7 +886,6 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
           "requires": {
             "nice-try": "1.0.5",
             "path-key": "2.0.1",
@@ -862,23 +913,23 @@
       }
     },
     "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
         "accepts": "1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "1.1.2",
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
@@ -886,35 +937,22 @@
         "parseurl": "1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "2.0.5",
-        "qs": "6.5.2",
-        "range-parser": "1.2.0",
+        "qs": "6.7.0",
+        "range-parser": "1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "1.5.0",
         "type-is": "1.6.18",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -958,7 +996,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": "0.7.3"
       }
     },
     "filename-regex": {
@@ -979,32 +1017,17 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.3",
-        "statuses": "1.4.0",
+        "statuses": "1.5.0",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "find-cache-dir": {
@@ -1022,7 +1045,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "3.0.0"
       }
@@ -1038,6 +1060,16 @@
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
         "debug": "3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        }
       }
     },
     "for-in": {
@@ -1088,17 +1120,38 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -1110,7 +1163,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
       "requires": {
         "pump": "3.0.0"
       },
@@ -1119,7 +1171,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
             "once": "1.4.0"
@@ -1254,6 +1305,11 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "hash-base": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -1285,20 +1341,21 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "setprototypeof": "1.1.1",
+        "statuses": "1.5.0",
+        "toidentifier": "1.0.0"
       }
     },
     "http-parser-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
-      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w=="
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
       "version": "1.17.0",
@@ -1332,11 +1389,19 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": "2.1.2"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "3.0.4"
       }
     },
     "imurmurhash": {
@@ -1349,7 +1414,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -1360,11 +1424,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -1405,6 +1473,14 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -1434,8 +1510,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1450,8 +1525,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
@@ -1629,9 +1703,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1656,7 +1730,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
       "requires": {
         "invert-kv": "2.0.0"
       }
@@ -1691,7 +1764,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "3.0.0",
         "path-exists": "3.0.0"
@@ -1744,7 +1816,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
       "requires": {
         "p-defer": "1.0.0"
       }
@@ -1763,7 +1834,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
       "requires": {
         "map-age-cleaner": "0.1.3",
         "mimic-fn": "2.1.0",
@@ -1862,14 +1932,17 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -1877,14 +1950,36 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1892,8 +1987,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -1938,6 +2032,31 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "needle": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "requires": {
+        "debug": "3.2.6",
+        "iconv-lite": "0.4.24",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -1978,8 +2097,33 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.4.0",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.4.4",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.3",
+        "semver": "5.7.0",
+        "tar": "4.4.10"
+      }
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2001,14 +2145,43 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+    },
+    "npm-packlist": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.6"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "14.1.1",
@@ -2064,6 +2237,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -2090,7 +2268,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -2127,43 +2304,51 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
       "requires": {
         "execa": "1.0.0",
         "lcid": "2.0.0",
         "mem": "4.3.0"
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-      "dev": true
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
       "requires": {
         "p-try": "2.2.0"
       }
@@ -2172,7 +2357,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "2.2.0"
       }
@@ -2180,8 +2364,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
       "version": "3.0.0",
@@ -2239,8 +2422,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2250,8 +2432,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -2307,6 +2488,11 @@
         "find-up": "3.0.0"
       }
     },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+    },
     "postinstall-build": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.3.tgz",
@@ -2319,9 +2505,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -2352,6 +2538,24 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qrcode": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.0.tgz",
+      "integrity": "sha512-18u+bdSosXO0+wx6F1UUFzJz01VRfMBcb/wbBw/tKYRD0A2Vho5WQ4xz30pHwhh4IE/qhObqIs5yNO0mGdHKkA==",
+      "requires": {
+        "dijkstrajs": "1.0.1",
+        "isarray": "2.0.5",
+        "pngjs": "3.4.0",
+        "yargs": "13.2.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
     },
     "qrcode-generator-ts": {
       "version": "0.0.4",
@@ -2394,19 +2598,37 @@
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "read-pkg": {
@@ -2438,7 +2660,7 @@
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
+        "process-nextick-args": "2.0.1",
         "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
@@ -2524,14 +2746,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -2557,7 +2777,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "7.1.4"
       },
@@ -2566,7 +2785,6 @@
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2610,16 +2828,20 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.2",
@@ -2628,32 +2850,12 @@
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "range-parser": "1.2.1",
+        "statuses": "1.5.0"
       }
     },
     "serve-index": {
@@ -2670,48 +2872,49 @@
         "parseurl": "1.3.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "ms": "2.0.0"
+            "depd": "1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.5.0"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.3",
-        "send": "0.16.2"
+        "send": "0.17.1"
       }
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -2719,14 +2922,27 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
+      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
+      }
     },
     "sockjs": {
       "version": "0.3.19",
@@ -2744,18 +2960,26 @@
       "requires": {
         "debug": "3.2.6",
         "eventsource": "1.0.7",
-        "faye-websocket": "0.11.1",
+        "faye-websocket": "0.11.3",
         "inherits": "2.0.3",
-        "json3": "3.3.2",
+        "json3": "3.3.3",
         "url-parse": "1.4.7"
       },
       "dependencies": {
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "websocket-driver": "0.7.0"
+            "ms": "2.1.1"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+          "requires": {
+            "websocket-driver": "0.7.3"
           }
         }
       }
@@ -2853,9 +3077,9 @@
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2866,6 +3090,16 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
       "integrity": "sha1-GsWtaDJCjKVWZ9ve45Xa1ObbEY8="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -2892,8 +3126,12 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "5.4.0",
@@ -2902,6 +3140,27 @@
       "dev": true,
       "requires": {
         "has-flag": "3.0.0"
+      }
+    },
+    "tar": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "requires": {
+        "chownr": "1.1.2",
+        "fs-minipass": "1.2.6",
+        "minipass": "2.3.5",
+        "minizlib": "1.2.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "test-exclude": {
@@ -2942,6 +3201,11 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -3041,9 +3305,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {
@@ -3148,7 +3412,7 @@
         "memory-fs": "0.4.1",
         "mime": "1.6.0",
         "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
+        "range-parser": "1.2.1",
         "time-stamp": "2.2.0"
       }
     },
@@ -3159,7 +3423,7 @@
       "requires": {
         "compression": "1.7.4",
         "connect-history-api-fallback": "1.6.0",
-        "express": "4.16.4",
+        "express": "4.17.1",
         "http-proxy-middleware": "0.17.4",
         "open": "0.0.5",
         "optimist": "0.6.1",
@@ -3188,11 +3452,12 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
-        "http-parser-js": "0.5.0",
+        "http-parser-js": "0.4.10",
+        "safe-buffer": "5.1.2",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -3205,7 +3470,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -3213,8 +3477,15 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -3225,7 +3496,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
         "string-width": "3.1.0",
@@ -3235,20 +3505,17 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "7.0.3",
             "is-fullwidth-code-point": "2.0.0",
@@ -3259,7 +3526,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "4.1.0"
           }
@@ -3269,8 +3535,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -3294,8 +3559,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -3307,7 +3571,6 @@
       "version": "13.2.4",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
       "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-      "dev": true,
       "requires": {
         "cliui": "5.0.0",
         "find-up": "3.0.0",
@@ -3325,20 +3588,17 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "7.0.3",
             "is-fullwidth-code-point": "2.0.0",
@@ -3349,7 +3609,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "4.1.0"
           }
@@ -3360,7 +3619,6 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "dev": true,
       "requires": {
         "camelcase": "5.3.1",
         "decamelize": "1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,14 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@types/bip32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bip32/-/bip32-1.0.2.tgz",
+      "integrity": "sha512-gqkz3Jq2OA3s5QOHe7de9tUzW7Xjoct6ImCbt0KQnF0ParqDSvLo5Fu+mKQykFF1fgIcdzEmm0CO6HN+xG2SAA==",
+      "requires": {
+        "@types/node": "12.6.1"
+      }
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -143,8 +151,7 @@
     "@types/node": {
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
-      "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ==",
-      "dev": true
+      "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ=="
     },
     "@types/qrcode": {
       "version": "1.3.3",
@@ -319,6 +326,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base-x": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -332,10 +347,59 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
+      "requires": {
+        "bs58check": "2.1.2",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "tiny-secp256k1": "1.1.3",
+        "typeforce": "1.18.0",
+        "wif": "2.0.6"
+      }
+    },
+    "bip39": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "1.2.0",
+        "pbkdf2": "3.0.17",
+        "randombytes": "2.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
+    },
+    "bip44-constants": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-8.0.4.tgz",
+      "integrity": "sha512-XoseKVNGMmehsVkZnxf/fOzS22oNhr/5cvSWFr/GGQc5XnxuAlEXQ4o1cK+brcSmixnT2cM0uanv69WI9dSXGQ=="
+    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
       "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -385,11 +449,34 @@
         "repeat-element": "1.1.3"
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "3.0.7"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "4.0.1",
+        "create-hash": "1.2.0",
+        "safe-buffer": "5.1.2"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -469,6 +556,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -662,6 +758,31 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
+      }
+    },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
@@ -785,6 +906,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elliptic": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -998,6 +1133,11 @@
       "requires": {
         "websocket-driver": "0.7.3"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1319,6 +1459,15 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
+      }
+    },
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -1333,6 +1482,16 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -1825,6 +1984,16 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1938,6 +2107,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2061,6 +2240,23 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nem2-hd-wallets": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/nem2-hd-wallets/-/nem2-hd-wallets-0.4.1.tgz",
+      "integrity": "sha512-pCmKzdtOKXWvHCFNgArzJ3PER1xwUMLaHV2ayk5kycTWIlADpG1oqC8WHB/HdbAvbJUg091Gsn/1VcUSINspbQ==",
+      "requires": {
+        "@types/bip32": "1.0.2",
+        "bip32": "1.0.4",
+        "bip39": "3.0.2",
+        "bip44-constants": "8.0.4",
+        "bs58check": "2.1.2",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "js-sha3": "0.8.0",
+        "nem2-sdk": "0.13.0",
+        "rxjs": "6.5.2"
+      }
     },
     "nem2-sdk": {
       "version": "0.13.0",
@@ -2468,6 +2664,18 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
+      }
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -2595,6 +2803,14 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -2911,6 +3127,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3196,6 +3421,18 @@
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
       "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA=="
     },
+    "tiny-secp256k1": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.3.tgz",
+      "integrity": "sha512-ZpobrhOtHP98VYEN51IYQH1YcrbFpnxFhI6ceWa3OEbJn7eHvSd8YFjGPxbedGCy7PNYU1v/+BRsdvyr5uRd4g==",
+      "requires": {
+        "bindings": "1.5.0",
+        "bn.js": "4.11.8",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.5.1",
+        "nan": "2.14.0"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3292,6 +3529,11 @@
           }
         }
       }
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typemoq": {
       "version": "2.1.0",
@@ -3485,6 +3727,14 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "1.0.2"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "2.1.2"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -8,22 +8,25 @@
     "test": "test"
   },
   "dependencies": {
+    "canvas": "^2.6.0",
     "crypto-js": "^3.1.9-1",
     "nem2-sdk": "^0.13.0",
+    "qrcode": "^1.4.0",
     "qrcode-generator-ts": "^0.0.4"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^12.0.12",
     "@types/crypto-js": "^3.1.43",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.6.1",
+    "@types/qrcode": "^1.3.3",
     "chai": "^4.1.2",
     "coveralls": "^3.0.4",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
     "ts-node": "^7.0.0",
     "typemoq": "^2.1.0",
-    "typescript": "^2.9.2"
+    "typescript": "~3.5.3"
   },
   "scripts": {
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "crypto-js": "^3.1.9-1",
     "nem2-sdk": "^0.13.0",
     "qrcode": "^1.4.0",
-    "qrcode-generator-ts": "^0.0.4"
+    "qrcode-generator-ts": "^0.0.4",
+    "nem2-hd-wallets": "0.4.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test": "mocha --ui bdd --recursive ./dist/test",
     "test:cov-html": "nyc --reporter=html npm t",
     "test:coverage": "nyc --reporter=text-lcov npm t",
-    "report-coverage": "nyc report --reporter=text-lcov | coveralls"
+    "report-coverage": "nyc report --reporter=text-lcov | coveralls",
+    "examples": "npm run build && node dist/examples/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/AccountQR.ts
+++ b/src/AccountQR.ts
@@ -39,7 +39,7 @@ export class AccountQR extends QRCode implements QRCodeInterface {
      *
      * @param   account     {Account}
      * @param   networkType     {NetworkType}
-     * @param   chainId         {string}
+     * @param   generationHash         {string}
      */
     constructor(/**
                  * The account to be exported
@@ -57,11 +57,11 @@ export class AccountQR extends QRCode implements QRCodeInterface {
                  */
                 public readonly networkType: NetworkType,
                 /**
-                 * The chain Id.
+                 * The network generation hash.
                  * @var {string}
                  */
-                public readonly chainId: string) {
-        super(QRCodeType.ExportAccount, networkType, chainId);
+                public readonly generationHash: string) {
+        super(QRCodeType.ExportAccount, networkType, generationHash);
     }
 
     /**

--- a/src/AccountQR.ts
+++ b/src/AccountQR.ts
@@ -93,7 +93,7 @@ export class AccountQR extends QRCode implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for AccountQR is Version 15
+        // Type version for AccountQR is Version 15, uses correction level M
         // This type of QR can hold up to 412 binary bytes.
         return 15;
     }

--- a/src/AccountQR.ts
+++ b/src/AccountQR.ts
@@ -89,12 +89,13 @@ export class AccountQR extends QRCode implements QRCodeInterface {
      * version number for QR codes of the underlying class.
      *
      * @see https://en.wikipedia.org/wiki/QR_code#Storage
+     * @see {QRUtil.MAX_LENGTH}
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 10
-        // This type of QR can hold up to 174 bytes of data.
-        return 20;
+        // Type version for AccountQR is Version 15
+        // This type of QR can hold up to 412 binary bytes.
+        return 15;
     }
 
     /**

--- a/src/ContactQR.ts
+++ b/src/ContactQR.ts
@@ -37,7 +37,7 @@ export class ContactQR extends QRCode implements QRCodeInterface {
      *
      * @param   account         {Account|PublicAccount}
      * @param   networkType     {NetworkType}
-     * @param   chainId         {string}
+     * @param   generationHash         {string}
      */
     constructor(/**
                  * The contact name.
@@ -55,11 +55,11 @@ export class ContactQR extends QRCode implements QRCodeInterface {
                  */
                 public readonly networkType: NetworkType,
                 /**
-                 * The chain Id.
+                 * The network generation hash.
                  * @var {string}
                  */
-                public readonly chainId: string) {
-        super(QRCodeType.AddContact, networkType, chainId);
+                public readonly generationHash: string) {
+        super(QRCodeType.AddContact, networkType, generationHash);
     }
 
     /**

--- a/src/ContactQR.ts
+++ b/src/ContactQR.ts
@@ -88,8 +88,8 @@ export class ContactQR extends QRCode implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 10
-        // This type of QR can hold up to 213 binary bytes.
+        // Type version for ContactQR is Version 15, uses correction level M
+        // This type of QR can hold up to 412 binary bytes.
         return 15;
     }
 

--- a/src/CosignatureQR.ts
+++ b/src/CosignatureQR.ts
@@ -84,8 +84,8 @@ export class CosignatureQR extends TransactionQR implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 40
-        // This type of QR can hold up to 1264 bytes of data.
+        // Type version for ContactQR is Version 40, uses correction level L
+        // This type of QR can hold up to 2953 bytes of data.
         return 40;
     }
 

--- a/src/CosignatureQR.ts
+++ b/src/CosignatureQR.ts
@@ -38,7 +38,7 @@ export class CosignatureQR extends TransactionQR implements QRCodeInterface {
      *
      * @param   transaction     {Transaction}
      * @param   networkType     {NetworkType}
-     * @param   chainId         {string}
+     * @param   generationHash         {string}
      */
     constructor(/**
                  * The transaction for the request.
@@ -51,11 +51,11 @@ export class CosignatureQR extends TransactionQR implements QRCodeInterface {
                  */
                 public readonly networkType: NetworkType,
                 /**
-                 * The chain Id.
+                 * The network generation hash.
                  * @var {string}
                  */
-                public readonly chainId: string) {
-        super(transaction, networkType, chainId, QRCodeType.RequestCosignature);
+                public readonly generationHash: string) {
+        super(transaction, networkType, generationHash, QRCodeType.RequestCosignature);
     }
 
     /**

--- a/src/MnemonicQR.ts
+++ b/src/MnemonicQR.ts
@@ -93,8 +93,8 @@ export class MnemonicQR extends QRCode implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for MnemonicQR is Version 20
-        // This type of QR can hold up to XXX binary bytes.
+        // Type version for MnemonicQR is Version 20, uses correction level M
+        // This type of QR can hold up to 666 binary bytes.
         return 20;
     }
 

--- a/src/MnemonicQR.ts
+++ b/src/MnemonicQR.ts
@@ -14,11 +14,10 @@
  *limitations under the License.
  */
 import {
-    Account,
-    PublicAccount,
     NetworkType,
-    Address,
+    Password,
 } from "nem2-sdk";
+import { MnemonicPassPhrase } from 'nem2-hd-wallets';
 
 // internal dependencies
 import {
@@ -26,29 +25,32 @@ import {
     QRCodeInterface,
     QRCodeType,
     QRCodeSettings,
+    EncryptionService,
+    EncryptedPayload,
     QRCodeDataSchema,
-    AddContactDataSchema
+    ExportMnemonicDataSchema
 } from '../index';
 
-export class ContactQR extends QRCode implements QRCodeInterface {
+export class MnemonicQR extends QRCode implements QRCodeInterface {
     /**
-     * Construct a Contact QR Code out of the
-     * nem2-sdk Account or PublicAccount instance.
+     * Construct a Mnemonic Export QR Code out of the
+     * MnemonicPassPhrase and Password instances.
      *
-     * @param   account         {Account|PublicAccount}
+     * @param   mnemonic        {MnemonicPassPhrase}
+     * @param   password        {Password}
      * @param   networkType     {NetworkType}
-     * @param   generationHash         {string}
+     * @param   generationHash  {string}
      */
     constructor(/**
-                 * The contact name.
-                 * @var {string}
+                 * The mnemonic pass phrase to be exported
+                 * @var {MnemonicPassPhrase}
                  */
-                public readonly name: string,
+                public readonly mnemonic: MnemonicPassPhrase,
                 /**
-                 * The contact account.
-                 * @var {Account|PublicAccount|Address}
+                 * The password for encryption
+                 * @var {Password}
                  */
-                public readonly account: Account | PublicAccount,
+                public readonly password: Password,
                 /**
                  * The network type.
                  * @var {NetworkType}
@@ -59,25 +61,27 @@ export class ContactQR extends QRCode implements QRCodeInterface {
                  * @var {string}
                  */
                 public readonly generationHash: string) {
-        super(QRCodeType.AddContact, networkType, generationHash);
+        super(QRCodeType.ExportMnemonic, networkType, generationHash);
     }
 
     /**
-     * Parse a JSON QR code content into a ContactQR
+     * Parse a JSON QR code content into a MnemonicQR
      * object.
      *
      * @param   json        {string}
-     * @return  {ContactQR}
+     * @param   password    {Password}
+     * @return  {MnemonicQR}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
      * @throws  {Error}     On unrecognized QR code `type` field value.
      */
     static fromJSON(
-        json: string
-    ): ContactQR {
+        json: string,
+        password: Password
+    ): MnemonicQR {
 
         // create the QRCode object from JSON
-        return AddContactDataSchema.parse(json);
+        return ExportMnemonicDataSchema.parse(json, password);
     }
 
     /**
@@ -85,12 +89,13 @@ export class ContactQR extends QRCode implements QRCodeInterface {
      * version number for QR codes of the underlying class.
      *
      * @see https://en.wikipedia.org/wiki/QR_code#Storage
+     * @see {QRUtil.MAX_LENGTH}
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 10
-        // This type of QR can hold up to 213 binary bytes.
-        return 15;
+        // Type version for MnemonicQR is Version 20
+        // This type of QR can hold up to XXX binary bytes.
+        return 20;
     }
 
     /**
@@ -101,6 +106,6 @@ export class ContactQR extends QRCode implements QRCodeInterface {
      * @return {QRCodeDataSchema}
      */
     public getSchema(): QRCodeDataSchema {
-        return new AddContactDataSchema();
+        return new ExportMnemonicDataSchema();
     }
 }

--- a/src/ObjectQR.ts
+++ b/src/ObjectQR.ts
@@ -82,8 +82,8 @@ export class ObjectQR extends QRCode implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 10
-        // This type of QR can hold up to 174 bytes of data.
+        // Type version for ContactQR is Version 10, uses correction level M
+        // This type of QR can hold up to 213 bytes of data.
         return 10;
     }
 

--- a/src/ObjectQR.ts
+++ b/src/ObjectQR.ts
@@ -36,7 +36,7 @@ export class ObjectQR extends QRCode implements QRCodeInterface {
      * 
      * @param   object          {Object}
      * @param   networkType     {NetworkType}
-     * @param   chainId         {string}
+     * @param   generationHash         {string}
      */
     constructor(/**
                  * The object to display
@@ -49,11 +49,11 @@ export class ObjectQR extends QRCode implements QRCodeInterface {
                  */
                 public readonly networkType: NetworkType,
                 /**
-                 * The chain Id.
+                 * The network generation hash.
                  * @var {string}
                  */
-                public readonly chainId: string) {
-        super(QRCodeType.ExportObject, networkType, chainId);
+                public readonly generationHash: string) {
+        super(QRCodeType.ExportObject, networkType, generationHash);
     }
 
     /**

--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -18,6 +18,9 @@ import {
     QR8BitByte,
 } from 'qrcode-generator-ts';
 
+import * as QRCodeCanvas from 'qrcode';
+import { createCanvas } from 'canvas';
+
 import {
     NetworkType,
 } from 'nem2-sdk';
@@ -139,26 +142,44 @@ export abstract class QRCode implements QRCodeInterface {
     }
 
     /**
-     * Generate an ASCII encoded QRcode. This encoding can be
-     * displayed in bash screens.
+     * 
+     */
+    public toASCII() {
+
+        // build the QR Code
+        const qr = this.build();
+
+        // encode with ASCII/MinimalASCII encoder
+        const encoder = new EncoderASCII(qr);
+
+        // return string representation
+        return encoder.toString();
+    }
+
+    /**
+     * Generate QRCode to be printed on a `node-canvas`. This
+     * is compatible with the browser and node.
      *
-     * @see {EncoderASCII}
+     * @see https://www.npmjs.com/package/qrcode
+     * @see https://www.npmjs.com/package/canvas
      * @param   {number}    cellSize     QRcode cell size
      * @param   {number}    margin       QRcode cell margin
      * @return  {string}
      */
-    public toASCII(
-        cellSize: number = QRCodeSettings.CELL_PIXEL_SIZE,
-        margin: number = QRCodeSettings.MARGIN_PIXEL
-    ): string {
+    public async toCanvas(): Promise<any> {
 
-        // build the QR code
-        const qr = this.build();
+        // get JSON representation
+        const json = this.toJSON();
 
-        // use ASCII encoder
-        const encoder = new EncoderASCII(qr, cellSize, margin);
+        // create canvas
+        const canvas = createCanvas(250, 250);
+        const context = canvas.getContext('2d');
 
-        // use encoder to get string representation
-        return encoder.toString();
+        // build the QR Code
+        return await QRCodeCanvas.toCanvas(canvas, json, {
+            errorCorrectionLevel: 'M',
+            width: 250,
+            // do-not-set-'version'
+        })
     }
 }

--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -14,6 +14,7 @@
  *limitations under the License.
  */
 import {
+    ErrorCorrectLevel,
     QRCode as QRCodeImpl,
     QR8BitByte,
 } from 'qrcode-generator-ts';
@@ -85,6 +86,19 @@ export abstract class QRCode implements QRCodeInterface {
     /// end-region Abstract Methods
 
     /**
+     * The `getCorrectionLevel()` method should return the
+     * QR Code correction level.
+     * 
+     * Sub-classes may overload this method to provide with
+     * a different correction level.
+     * 
+     * @return {number}
+     */
+    public getCorrectionLevel(): number {
+        return QRCodeSettings.CORRECTION_LEVEL;
+    }
+
+    /**
      * The `toJSON()` method should return the JSON
      * representation of the QR Code content.
      *
@@ -113,7 +127,7 @@ export abstract class QRCode implements QRCodeInterface {
         // prepare QR generation
         const qr = new QRCodeImpl();
         qr.setTypeNumber(this.getTypeNumber());
-        qr.setErrorCorrectLevel(QRCodeSettings.CORRECTION_LEVEL);
+        qr.setErrorCorrectLevel(this.getCorrectionLevel());
 
         // get JSON representation
         const json = this.toJSON();
@@ -142,7 +156,9 @@ export abstract class QRCode implements QRCodeInterface {
     }
 
     /**
-     * 
+     * Generate QRCode to be printed in ASCII format.
+     *
+     * @return {string}
      */
     public toASCII() {
 
@@ -175,11 +191,18 @@ export abstract class QRCode implements QRCodeInterface {
         const canvas = createCanvas(250, 250);
         const context = canvas.getContext('2d');
 
+        // QRCodeCanvas correction level
+        const corrections: any = {};
+        corrections[ErrorCorrectLevel.L] = 'L';
+        corrections[ErrorCorrectLevel.M] = 'M';
+        corrections[ErrorCorrectLevel.Q] = 'Q';
+        corrections[ErrorCorrectLevel.H] = 'H';
+
         // build the QR Code
         return await QRCodeCanvas.toCanvas(canvas, json, {
-            errorCorrectionLevel: 'M',
+            errorCorrectionLevel: corrections[this.getCorrectionLevel()],
             width: 250,
             // do-not-set-'version'
-        })
+        });
     }
 }

--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -16,12 +16,10 @@
 import {
     QRCode as QRCodeImpl,
     QR8BitByte,
-    ErrorCorrectLevel,
 } from 'qrcode-generator-ts';
 
 import {
     NetworkType,
-    Password
 } from 'nem2-sdk';
 
 // internal dependencies
@@ -30,6 +28,7 @@ import {
     QRCodeType,
     QRCodeSettings,
     QRCodeDataSchema,
+    EncoderASCII,
 } from "../index";
 
 export abstract class QRCode implements QRCodeInterface {
@@ -127,7 +126,7 @@ export abstract class QRCode implements QRCodeInterface {
      *
      * @return  {string} Retrun image data in Base64.
      */
-    public toBase64() : string {
+    public toBase64(): string {
 
         // build QR Code
         const qr = this.build();
@@ -137,5 +136,23 @@ export abstract class QRCode implements QRCodeInterface {
             QRCodeSettings.CELL_PIXEL_SIZE,
             QRCodeSettings.MARGIN_PIXEL
         );
+    }
+
+    /**
+     * 
+     */
+    public toASCII(
+        cellSize: number = QRCodeSettings.CELL_PIXEL_SIZE,
+        margin: number = QRCodeSettings.MARGIN_PIXEL
+    ): string {
+
+        // build the QR code
+        const qr = this.build();
+
+        // use ASCII encoder
+        const encoder = new EncoderASCII(qr, cellSize, margin);
+
+        // use encoder to get string representation
+        return encoder.toString();
     }
 }

--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -51,10 +51,10 @@ export abstract class QRCode implements QRCodeInterface {
                  */
                 public readonly networkType: NetworkType,
                 /**
-                 * The chain ID.
+                 * The network generation hash.
                  * @var {string}
                  */
-                public readonly chainId: string,
+                public readonly generationHash: string,
                 /**
                  * The base64 representation of the QR Code content.
                  * @var {string}
@@ -124,7 +124,7 @@ export abstract class QRCode implements QRCodeInterface {
     /**
      * Generate QRcode image Base64.
      *
-     * @return  {string} Retrun image data in Base64.
+     * @return  {string} Return image data in Base64.
      */
     public toBase64(): string {
 
@@ -139,7 +139,13 @@ export abstract class QRCode implements QRCodeInterface {
     }
 
     /**
-     * 
+     * Generate an ASCII encoded QRcode. This encoding can be
+     * displayed in bash screens.
+     *
+     * @see {EncoderASCII}
+     * @param   {number}    cellSize     QRcode cell size
+     * @param   {number}    margin       QRcode cell margin
+     * @return  {string}
      */
     public toASCII(
         cellSize: number = QRCodeSettings.CELL_PIXEL_SIZE,

--- a/src/QRCodeDataSchema.ts
+++ b/src/QRCodeDataSchema.ts
@@ -60,7 +60,7 @@ export abstract class QRCodeDataSchema {
             "v": this.VERSION,
             "type": qr.type,
             "network_id": qr.networkType,
-            "chain_id": qr.chainId,
+            "chain_id": qr.generationHash,
             "data": data
         };
     }

--- a/src/QRCodeGenerator.ts
+++ b/src/QRCodeGenerator.ts
@@ -21,6 +21,7 @@ import {
     PublicAccount,
     Password
 } from "nem2-sdk";
+import { MnemonicPassPhrase } from 'nem2-hd-wallets';
 
 // internal dependencies
 import {
@@ -31,7 +32,8 @@ import {
     ContactQR,
     ObjectQR,
     TransactionQR,
-    CosignatureQR
+    CosignatureQR,
+    MnemonicQR,
 } from '../index';
 
 /**
@@ -84,11 +86,12 @@ export class QRCodeGenerator {
     }
 
     /**
-     * Create a Transaction Request QR Code from a Transaction
-     * instance.
+     * Create an Account Export QR Code from an Account
+     * instance, encrypted with given password.
      *
      * @see {AccountQR}
-     * @param   transaction     {Transaction}
+     * @param   account         {Account}
+     * @param   password        {Password}
      * @param   networkType     {NetworkType}
      * @param   chainId         {string}
      */
@@ -116,6 +119,25 @@ export class QRCodeGenerator {
         chainId: string = 'E2A9F95E129283EF47B92A62FD748DBA4D32AA718AE6F8AC99C105CFA9F27A31'
     ): TransactionQR {
         return new TransactionQR(transaction, networkType, chainId);
+    }
+
+    /**
+     * Create a Mnemonic Export QR Code from an Account
+     * instance, encrypted with given password.
+     *
+     * @see {MnemonicQR}
+     * @param   mnemonic        {MnemonicPassPhrase}
+     * @param   password        {Password}
+     * @param   networkType     {NetworkType}
+     * @param   chainId         {string}
+     */
+    public static createExportMnemonic(
+        mnemonic: MnemonicPassPhrase,
+        password: Password,
+        networkType: NetworkType = NetworkType.MIJIN_TEST,
+        chainId: string = 'E2A9F95E129283EF47B92A62FD748DBA4D32AA718AE6F8AC99C105CFA9F27A31'
+    ): MnemonicQR {
+        return new MnemonicQR(mnemonic, password, networkType, chainId);
     }
 
     /**
@@ -181,6 +203,16 @@ export class QRCodeGenerator {
         // create a TransactionQR from JSON
         case QRCodeType.RequestTransaction:
             return TransactionQR.fromJSON(json);
+
+        // create an MnemonicQR from JSON
+        case QRCodeType.ExportMnemonic:
+
+            // password obligatory for encryption
+            if (! password) {
+                throw new Error('Missing password to decrypt MnemonicQR QR code.');
+            }
+
+            return MnemonicQR.fromJSON(json, password);
 
         default:
             break;

--- a/src/QRCodeGenerator.ts
+++ b/src/QRCodeGenerator.ts
@@ -122,7 +122,7 @@ export class QRCodeGenerator {
     }
 
     /**
-     * Create a Mnemonic Export QR Code from an Account
+     * Create a Mnemonic Export QR Code from a MnemonicPassPhrase
      * instance, encrypted with given password.
      *
      * @see {MnemonicQR}

--- a/src/QRCodeSettings.ts
+++ b/src/QRCodeSettings.ts
@@ -33,7 +33,7 @@ export class QRCodeSettings {
      *
      * @var {ErrorCorrectLevel}
      */
-    public static CORRECTION_LEVEL = ErrorCorrectLevel.L;
+    public static CORRECTION_LEVEL = ErrorCorrectLevel.M;
 
     /**
      * The QR Code cell size in pixels.

--- a/src/QrCodeType.ts
+++ b/src/QrCodeType.ts
@@ -19,4 +19,5 @@ export enum QRCodeType {
     RequestTransaction = 3,
     RequestCosignature = 4,
     ExportObject = 5,
+    ExportMnemonic = 6,
 }

--- a/src/TransactionQR.ts
+++ b/src/TransactionQR.ts
@@ -18,6 +18,9 @@ import {
     TransactionMapping,
     Transaction,
 } from "nem2-sdk";
+import {
+    ErrorCorrectLevel,
+} from 'qrcode-generator-ts';
 
 // internal dependencies
 import {
@@ -81,6 +84,21 @@ export class TransactionQR extends QRCode implements QRCodeInterface {
     }
 
     /**
+     * The `getCorrectionLevel()` method should return the
+     * QR Code correction level.
+     * 
+     * Sub-classes may overload this method to provide with
+     * a different correction level.
+     * 
+     * @return {number}
+     */
+    public getCorrectionLevel(): number {
+        // transaction request QR codes uses correction level L to
+        // increase capacity of the QR Code binary data.
+        return ErrorCorrectLevel.L;
+    }
+
+    /**
      * The `getTypeNumber()` method should return the
      * version number for QR codes of the underlying class.
      *
@@ -88,8 +106,8 @@ export class TransactionQR extends QRCode implements QRCodeInterface {
      * @return {number}
      */
     public getTypeNumber(): number {
-        // Type version for ContactQR is Version 40
-        // This type of QR can hold up to 1264 bytes of data.
+        // Type version for ContactQR is Version 40, uses correction level L
+        // This type of QR can hold up to 2953 bytes of data.
         return 40;
     }
 

--- a/src/TransactionQR.ts
+++ b/src/TransactionQR.ts
@@ -36,7 +36,7 @@ export class TransactionQR extends QRCode implements QRCodeInterface {
      *
      * @param   transaction     {Transaction}
      * @param   networkType     {NetworkType}
-     * @param   chainId         {string}
+     * @param   generationHash         {string}
      */
     constructor(/**
                  * The transaction for the request.
@@ -52,14 +52,14 @@ export class TransactionQR extends QRCode implements QRCodeInterface {
                  * The chain Id.
                  * @var {string}
                  */
-                public readonly chainId: string,
+                public readonly generationHash: string,
                 /**
                  * The QR Code Type
                  * 
                  * @var {QRCodeType} 
                  */
                 public readonly type: QRCodeType = QRCodeType.RequestTransaction) {
-        super(type, networkType, chainId);
+        super(type, networkType, generationHash);
     }
 
     /**

--- a/src/encoders/EncoderASCII.ts
+++ b/src/encoders/EncoderASCII.ts
@@ -24,28 +24,54 @@ import {
     QRCodeSettings,
 } from "../../index";
 
+/**
+ * Class `EncoderASCII` describes encoders utilities
+ * for QR Codes that are to be displayed with the 
+ * ASCII character set.
+ *
+ * @since 0.3.2
+ */
 export class EncoderASCII implements EncoderInterface {
 
     /**
+     * Construct an ASCII encoder for said `qr` QR Code.
      * 
+     * @param   {QRCodeImpl}    qr          The QRCode to encode.
+     * @param   {number}        cellSize    The QRCode cell size.
+     * @param   {number}        margin      The QRCode cell margin.
      */
     constructor(/**
-                 * 
+                 * The QR Code that will be encoded.
+                 * @var {QRCodeImpl}
                  */
                 public readonly qr: QRCodeImpl,
                 /**
-                 * 
+                 * The Cell Size used for encoding in Pixel.
+                 * @var {number}
                  */
                 public readonly cellSize: number = QRCodeSettings.CELL_PIXEL_SIZE,
                 /**
-                 * 
+                 * The Cell Size used for encoding in Pixel.
+                 * @var {number}
                  */
                 public readonly margin: number = QRCodeSettings.MARGIN_PIXEL) {
 
     }
 
     /**
-     * 
+     * The `toString()` method should return a string
+     * representation for the encoded QR Code.
+     *
+     * This specialization uses the ASCII encoding with
+     * a cell size of at least *2*. The margin can be custom
+     * or undefined and will then be set to _double the cell
+     * size_.
+     *
+     * This implementation is a Typescript rewrite of the ASCII
+     * encoding in below listed package.
+     *
+     * @see https://github.com/1w2w3y/qrcode-generator-ts
+     * @return  {string}    The ASCII encoded QRCode.
      */
     public toString(): string {
 

--- a/src/encoders/EncoderASCII.ts
+++ b/src/encoders/EncoderASCII.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    QRCode as QRCodeImpl,
+} from 'qrcode-generator-ts';
+
+// internal dependencies
+import {
+    EncoderInterface,
+    EncoderMinimalASCII,
+    QRCodeSettings,
+} from "../../index";
+
+export class EncoderASCII implements EncoderInterface {
+
+    /**
+     * 
+     */
+    constructor(/**
+                 * 
+                 */
+                public readonly qr: QRCodeImpl,
+                /**
+                 * 
+                 */
+                public readonly cellSize: number = QRCodeSettings.CELL_PIXEL_SIZE,
+                /**
+                 * 
+                 */
+                public readonly margin: number = QRCodeSettings.MARGIN_PIXEL) {
+
+    }
+
+    /**
+     * 
+     */
+    public toString(): string {
+
+        // use MinimalASCII for smaller cellSize
+        if (this.cellSize < 2) {
+            const encoder = new EncoderMinimalASCII(this.qr);
+            return encoder.toString();
+        }
+
+        // prepare dimensions
+        const cellSize = this.cellSize - 1;
+        const margin = this.margin || this.cellSize * 2;
+
+        // prepare iterations
+        const size = this.qr.getModuleCount() * cellSize + margin * 2;
+        const min = margin;
+        const max = size - margin;
+        let y, x, r, p;
+
+        // prepare colors (double character to fill square)
+        const white = Array(cellSize+1).join('██');
+        const black = Array(cellSize+1).join('  ');
+
+        // iterate through rows of QR
+        let ascii = '';
+        let line = '';
+        for (y = 0; y < size; y += 1) {
+
+            // reinitialize current row
+            r = Math.floor((y - min) / cellSize);
+            line = '';
+
+            // iterate through columns of QR row
+            for (x = 0; x < size; x += 1) {
+                p = 1;
+
+                if (min <= x && x < max 
+                 && min <= y && y < max 
+                 && this.qr.isDark(r, Math.floor((x - min) / cellSize))) {
+                    p = 0;
+                }
+
+                // Output 2 characters per pixel, to create full square.
+                // 1 character per pixels gives only half width of square.
+                line += p ? white : black;
+            }
+
+            // append generated line to ASCII
+            for (r = 0; r < cellSize; r += 1) {
+                ascii += line + '\n';
+            }
+        }
+
+        // trim last end-of-line
+        return ascii.substring(0, ascii.length-1);
+    }
+}

--- a/src/encoders/EncoderInterface.ts
+++ b/src/encoders/EncoderInterface.ts
@@ -21,7 +21,7 @@ import {
  * Interface `EncoderInterface` describes encoders utilities
  * for QR Codes that are compliant with NIP-7
  *
- * @since 0.3.1
+ * @since 0.3.2
  */
 export interface EncoderInterface {
 
@@ -44,7 +44,10 @@ export interface EncoderInterface {
     margin: number;
 
     /**
-     * 
+     * The `toString()` method should return a string
+     * representation for the encoded QR Code.
+     *
+     * @return {string}
      */
     toString(): string;
 }

--- a/src/encoders/EncoderInterface.ts
+++ b/src/encoders/EncoderInterface.ts
@@ -14,38 +14,37 @@
  *limitations under the License.
  */
 import {
-    ErrorCorrectLevel,
+    QRCode as QRCodeImpl,
 } from 'qrcode-generator-ts';
 
-// internal dependencies
-import {QRCodeType} from '../index';
-
 /**
- * Class `QRCodeSettings` describes rules for the generation
- * of NIP-7 compliant QR Codes.
+ * Interface `EncoderInterface` describes encoders utilities
+ * for QR Codes that are compliant with NIP-7
  *
- * @since 0.2.0
+ * @since 0.3.1
  */
-export class QRCodeSettings {
+export interface EncoderInterface {
 
     /**
-     * The Error correction level.
-     *
-     * @var {ErrorCorrectLevel}
+     * The QR Code that will be encoded.
+     * @var {QRCodeImpl}
      */
-    public static CORRECTION_LEVEL = ErrorCorrectLevel.L;
+    qr: QRCodeImpl;
 
     /**
-     * The QR Code cell size in pixels.
-     *
-     * @var {number}
+     * The Cell Size used for encoding in Pixel.
+     * @var {number}
      */
-    public static CELL_PIXEL_SIZE: number = 1;
+    cellSize: number;
 
     /**
-     * The QR Code Margin in pixels.
-     *
-     * @var {number}
+     * The margin used for encoding in Pixel
+     * @var {number}
      */
-    public static MARGIN_PIXEL: number = 2;
+    margin: number;
+
+    /**
+     * 
+     */
+    toString(): string;
 }

--- a/src/encoders/EncoderMinimalASCII.ts
+++ b/src/encoders/EncoderMinimalASCII.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    QRCode as QRCodeImpl,
+} from 'qrcode-generator-ts';
+
+// internal dependencies
+import {
+    EncoderInterface,
+    QRCodeSettings,
+} from "../../index";
+
+export class EncoderMinimalASCII implements EncoderInterface {
+
+    /**
+     * 
+     */
+    public readonly cellSize: number = 1;
+    /**
+     * 
+     */
+    public readonly margin: number = 2;
+
+    /**
+     * 
+     */
+    constructor(/**
+                 * 
+                 */
+                public readonly qr: QRCodeImpl,) {
+
+    }
+
+    /**
+     * 
+     */
+    public toString(): string {
+
+        // prepare dimensions
+        const cellSize = 1;
+        const margin = cellSize * 2;
+
+        // prepare iterations
+        const size = this.qr.getModuleCount() * cellSize + margin * 2;
+        const min = margin;
+        const max = size - margin;
+        let y, x, r1, r2, p;
+
+        // prepare block types
+        const blocks: any = {
+            '██': '█',
+            '█ ': '▀',
+            ' █': '▄',
+            '  ': ' '
+        };
+
+        const blocksLastLineNoMargin: any = {
+            '██': '▀',
+            '█ ': '▀',
+            ' █': ' ',
+            '  ': ' '
+        };
+
+        // iterate through rows of QR
+        var ascii = '';
+        for (y = 0; y < size; y += 2) {
+
+            // reinitialize current row
+            r1 = Math.floor((y - min) / cellSize);
+            r2 = Math.floor((y + 1 - min) / cellSize);
+
+            // iterate through columns of QR row
+            for (x = 0; x < size; x += 1) {
+                p = '█';
+
+                // is current column dark and in-row ?
+                if (min <= x && x < max 
+                 && min <= y && y < max 
+                 && this.qr.isDark(r1, Math.floor((x - min) / cellSize))) {
+                    p = ' ';
+                }
+
+                // is current column *on next row* dark ?
+                if (min <= x && x < max 
+                 && min <= y+1 && y+1 < max
+                 && this.qr.isDark(r2, Math.floor((x - min) / cellSize))) {
+                    p += ' ';
+                }
+                else {
+                    p += '█';
+                }
+
+                // output 2 characters per pixel, to create full square.
+                // 1 character per pixels gives only half width of square.
+                ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+            }
+
+            ascii += '\n';
+        }
+
+        // do we need padding ?
+        if (size % 2 && margin > 0) {
+            return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+        }
+
+        // trim last end-of-line
+        return ascii.substring(0, ascii.length-1);
+    }
+}

--- a/src/schemas/AddContactDataSchema.ts
+++ b/src/schemas/AddContactDataSchema.ts
@@ -79,8 +79,8 @@ export class AddContactDataSchema extends QRCodeDataSchema {
         const name = jsonObj.data.name;
         const network = jsonObj.network_id;
         const account = PublicAccount.createFromPublicKey(jsonObj.data.publicKey, network);
-        const chainId = jsonObj.chain_id;
+        const generationHash = jsonObj.chain_id;
 
-        return new ContactQR(name, account, network, chainId);
+        return new ContactQR(name, account, network, generationHash);
     }
 }

--- a/src/schemas/ExportAccountDataSchema.ts
+++ b/src/schemas/ExportAccountDataSchema.ts
@@ -85,10 +85,22 @@ export class ExportAccountDataSchema extends QRCodeDataSchema {
             throw new Error('Invalid type field value for AccountQR.');
         }
 
+        if (!jsonObj.hasOwnProperty('data')) {
+            throw new Error('Missing mandatory property for encrypted payload.');
+        }
+
         try {
+            // encrypted payload validation
+            const payload = EncryptedPayload.fromJSON(JSON.stringify(jsonObj.data));
+
             // decrypt private key
-            const payload = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
             const privKey = EncryptionService.decrypt(payload, password);
+
+            // more content validation
+            if (!privKey || (privKey.length != 64 && privKey.length != 66)) {
+                throw new Error('Invalid encrypted private key.');
+            }
+
             const network = jsonObj.network_id;
             const generationHash = jsonObj.chain_id;
 

--- a/src/schemas/ExportAccountDataSchema.ts
+++ b/src/schemas/ExportAccountDataSchema.ts
@@ -88,10 +88,10 @@ export class ExportAccountDataSchema extends QRCodeDataSchema {
         const payload = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
         const privKey = EncryptionService.decrypt(payload, password);
         const network = jsonObj.network_id;
-        const chainId = jsonObj.chain_id;
+        const generationHash = jsonObj.chain_id;
 
         // create account
         const account = Account.createFromPrivateKey(privKey, network);
-        return new AccountQR(account, password, network, chainId);
+        return new AccountQR(account, password, network, generationHash);
     }
 }

--- a/src/schemas/ExportMnemonicDataSchema.ts
+++ b/src/schemas/ExportMnemonicDataSchema.ts
@@ -69,22 +69,23 @@ export class ExportMnemonicDataSchema extends QRCodeDataSchema {
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
      * @throws  {Error}     On unrecognized QR code `type` field value.
+     * @throws  {Error}     On invalid password.
      */
     static parse(
         json: string,
         password: Password
     ): MnemonicQR {
         if (! json.length) {
-            throw Error('JSON argument cannot be empty.');
+            throw new Error('JSON argument cannot be empty.');
         }
 
         const jsonObj = JSON.parse(json);
         if (!jsonObj.type || jsonObj.type !== QRCodeType.ExportMnemonic) {
-            throw Error('Invalid type field value for MnemonicQR.');
+            throw new Error('Invalid type field value for MnemonicQR.');
         }
 
-        // decrypt mnemonic pass phrase
         try {
+            // decrypt mnemonic pass phrase
             const payload  = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
             const plainTxt = EncryptionService.decrypt(payload, password);
             const network  = jsonObj.network_id;
@@ -95,7 +96,7 @@ export class ExportMnemonicDataSchema extends QRCodeDataSchema {
             return new MnemonicQR(mnemonic, password, network, generationHash);
         }
         catch(e) {
-            throw Error('Invalid password.');
+            throw new Error('Could not parse encrypted mnemonic pass phrase.');
         }
     }
 }

--- a/src/schemas/ExportMnemonicDataSchema.ts
+++ b/src/schemas/ExportMnemonicDataSchema.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {
+    NetworkType,
+    Password,
+} from "nem2-sdk";
+import { MnemonicPassPhrase } from 'nem2-hd-wallets';
+
+// internal dependencies
+import {
+    QRCodeDataSchema,
+    QRCode,
+    QRCodeType,
+    MnemonicQR,
+    EncryptionService,
+    EncryptedPayload,
+} from '../../index';
+
+/**
+ * Class `ExportMnemonicDataSchema` describes an export
+ * account QR code data schema.
+ *
+ * @since 0.3.2
+ */
+export class ExportMnemonicDataSchema extends QRCodeDataSchema {
+
+    constructor() {
+        super();
+    }
+
+    /**
+     * The `getData()` method returns an object
+     * that will be stored in the `data` field of
+     * the underlying QR Code JSON content.
+     *
+     * @return {any}
+     */
+    public getData(qr: MnemonicQR): any {
+
+        // we will store a password encrypted copy of the private key
+        const encrypted = EncryptionService.encrypt(qr.mnemonic.plain, qr.password);
+
+        return {
+            "ciphertext": encrypted.ciphertext,
+            "salt": encrypted.salt,
+        };
+    }
+
+    /**
+     * Parse a JSON QR code content into a MnemonicQR
+     * object.
+     *
+     * @param   json        {string}
+     * @param   password    {Password}
+     * @return  {MnemonicQR}
+     * @throws  {Error}     On empty `json` given.
+     * @throws  {Error}     On missing `type` field value.
+     * @throws  {Error}     On unrecognized QR code `type` field value.
+     */
+    static parse(
+        json: string,
+        password: Password
+    ): MnemonicQR {
+        if (! json.length) {
+            throw Error('JSON argument cannot be empty.');
+        }
+
+        const jsonObj = JSON.parse(json);
+        if (!jsonObj.type || jsonObj.type !== QRCodeType.ExportMnemonic) {
+            throw Error('Invalid type field value for MnemonicQR.');
+        }
+
+        // decrypt mnemonic pass phrase
+        const payload  = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
+        const plainTxt = EncryptionService.decrypt(payload, password);
+        const network  = jsonObj.network_id;
+        const generationHash = jsonObj.chain_id;
+
+        // create mnemonic
+        const mnemonic = new MnemonicPassPhrase(plainTxt);
+        return new MnemonicQR(mnemonic, password, network, generationHash);
+    }
+}

--- a/src/schemas/ExportMnemonicDataSchema.ts
+++ b/src/schemas/ExportMnemonicDataSchema.ts
@@ -84,13 +84,18 @@ export class ExportMnemonicDataSchema extends QRCodeDataSchema {
         }
 
         // decrypt mnemonic pass phrase
-        const payload  = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
-        const plainTxt = EncryptionService.decrypt(payload, password);
-        const network  = jsonObj.network_id;
-        const generationHash = jsonObj.chain_id;
+        try {
+            const payload  = new EncryptedPayload(jsonObj.data.ciphertext, jsonObj.data.salt);
+            const plainTxt = EncryptionService.decrypt(payload, password);
+            const network  = jsonObj.network_id;
+            const generationHash = jsonObj.chain_id;
 
-        // create mnemonic
-        const mnemonic = new MnemonicPassPhrase(plainTxt);
-        return new MnemonicQR(mnemonic, password, network, generationHash);
+            // create mnemonic
+            const mnemonic = new MnemonicPassPhrase(plainTxt);
+            return new MnemonicQR(mnemonic, password, network, generationHash);
+        }
+        catch(e) {
+            throw Error('Invalid password.');
+        }
     }
 }

--- a/src/schemas/ExportObjectDataSchema.ts
+++ b/src/schemas/ExportObjectDataSchema.ts
@@ -70,8 +70,8 @@ export class ExportObjectDataSchema extends QRCodeDataSchema {
         // read contact data
         const obj = jsonObj.data;
         const network = jsonObj.network_id;
-        const chainId = jsonObj.chain_id;
+        const generationHash = jsonObj.chain_id;
 
-        return new ObjectQR(obj, network, chainId);
+        return new ObjectQR(obj, network, generationHash);
     }
 }

--- a/src/schemas/RequestCosignatureDataSchema.ts
+++ b/src/schemas/RequestCosignatureDataSchema.ts
@@ -59,7 +59,7 @@ export class RequestCosignatureDataSchema extends RequestTransactionDataSchema {
         }
 
         const jsonObj = JSON.parse(json);
-        if (!jsonObj.type || jsonObj.type !== QRCodeType.RequestTransaction) {
+        if (!jsonObj.type || jsonObj.type !== QRCodeType.RequestCosignature) {
             throw Error('Invalid type field value for CosignatureQR.');
         }
 

--- a/src/schemas/RequestCosignatureDataSchema.ts
+++ b/src/schemas/RequestCosignatureDataSchema.ts
@@ -66,8 +66,8 @@ export class RequestCosignatureDataSchema extends RequestTransactionDataSchema {
         // read contact data
         const transaction = TransactionMapping.createFromPayload(jsonObj.data.payload);
         const network = jsonObj.network_id;
-        const chainId = jsonObj.chain_id;
+        const generationHash = jsonObj.chain_id;
 
-        return new CosignatureQR(transaction as AggregateTransaction, network, chainId);
+        return new CosignatureQR(transaction as AggregateTransaction, network, generationHash);
     }
 }

--- a/src/schemas/RequestTransactionDataSchema.ts
+++ b/src/schemas/RequestTransactionDataSchema.ts
@@ -81,8 +81,8 @@ export class RequestTransactionDataSchema extends QRCodeDataSchema {
         // read contact data
         const transaction = TransactionMapping.createFromPayload(jsonObj.data.payload);
         const network = jsonObj.network_id;
-        const chainId = jsonObj.chain_id;
+        const generationHash = jsonObj.chain_id;
 
-        return new TransactionQR(transaction, network, chainId);
+        return new TransactionQR(transaction, network, generationHash);
     }
 }

--- a/test/AccountQR.spec.ts
+++ b/test/AccountQR.spec.ts
@@ -90,6 +90,26 @@ describe('AccountQR -->', () => {
             })).to.throw('Could not parse encrypted account information.');
         });
 
+        it('throw error given encrypted payload is invalid', () => {
+            // Arrange:
+            let accountInfo:any = {
+                v: 3,
+                type: QRCodeType.ExportAccount,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    // 'ciphertext' field for encrypted payload missing
+                    salt: '42c8615bc6b2bc88cd239f08a5a17cc62bb0ebaece53f3e458a1cd67cd0888bc'
+                }
+            };
+            const password = new Password('password');
+
+            // Act + Assert
+            expect((function () {
+                const importAccount = AccountQR.fromJSON(JSON.stringify(accountInfo), password);
+            })).to.throw('Could not parse encrypted account information.');
+        });
+
         it('reconstruct account given correct password', () => {
             // Arrange:
             const account = Account.createFromPrivateKey(

--- a/test/AccountQR.spec.ts
+++ b/test/AccountQR.spec.ts
@@ -23,6 +23,7 @@ import {
 // internal dependencies
 import {
     AccountQR,
+    QRCodeType,
 } from "../index";
 
 describe('AccountQR -->', () => {
@@ -66,6 +67,66 @@ describe('AccountQR -->', () => {
             // Assert:
             expect(actualObject.data).to.have.property('ciphertext');
             expect(actualObject.data).to.have.property('salt');
+        });
+    });
+
+    describe('fromJSON() should', () => {
+
+        it('throw error given wrong password', () => {
+            // Arrange:
+            const account = Account.createFromPrivateKey(
+                'F97AE23C2A28ECEDE6F8D6C447C0A10B55C92DDE9316CCD36C3177B073906978',
+                NetworkType.MIJIN_TEST
+            );
+            const password = new Password('password');
+            const wrongPw = new Password('passw0rd');
+
+            // Act:
+            const exportAccount = new AccountQR(account, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+
+            // Act + Assert
+            expect((function () {
+                const importAccount = AccountQR.fromJSON(exportAccount.toJSON(), wrongPw);
+            })).to.throw('Could not parse encrypted account information.');
+        });
+
+        it('reconstruct account given correct password', () => {
+            // Arrange:
+            const account = Account.createFromPrivateKey(
+                'F97AE23C2A28ECEDE6F8D6C447C0A10B55C92DDE9316CCD36C3177B073906978',
+                NetworkType.MIJIN_TEST
+            );
+            const password = new Password('password');
+
+            // Act:
+            const exportAccount = new AccountQR(account, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const importAccount = AccountQR.fromJSON(exportAccount.toJSON(), password);
+
+            // Assert
+            expect(importAccount.account.privateKey).to.be.equal(exportAccount.account.privateKey);
+            expect(importAccount.account.publicKey).to.be.equal(exportAccount.account.publicKey);
+        });
+
+        it('reconstruct account given correct ciphertext and password', () => {
+            // Arrange:
+            const accountInfo = {
+                v: 3,
+                type: QRCodeType.ExportAccount,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    ciphertext: '56d310848ee93d0794eb1f64a5195778ded2q7IxvtPbO+sA7jZZyhpu/khbaNdx1pzuoGoPJRw1A4aBsWPlex3y/gy5da8WjF0i4d+/D0B5ESy+zX5P+AoFAw3EFi3UVBdnav4rnqg=',
+                    salt: '42c8615bc6b2bc88cd239f08a5a17cc62bb0ebaece53f3e458a1cd67cd0888bc'
+                }
+            };
+            const password = new Password('password');
+
+            // Act:
+            const importAccount = AccountQR.fromJSON(JSON.stringify(accountInfo), password);
+
+            // Assert
+            expect(importAccount.account.privateKey).to.be.equal('749F1FF1972CD465CAB74566FF0AA021F846FBE3916ABB6A6C1373E962C76331');
+            expect(importAccount.account.publicKey).to.be.equal('9741183860ED711BD986A464004DB9A6D26B25F4CBB51F3B0FF1B220510B86B0');
         });
     });
 

--- a/test/ContactQR.spec.ts
+++ b/test/ContactQR.spec.ts
@@ -22,6 +22,7 @@ import {
 // internal dependencies
 import {
     ContactQR,
+    QRCodeType,
 } from "../index";
 
 describe('ContactQR -->', () => {
@@ -66,6 +67,47 @@ describe('ContactQR -->', () => {
             expect(actualObject.data).to.have.property('name');
             expect(actualObject.data).to.have.property('publicKey');
         });
+    });
+
+    describe('fromJSON() should', () => {
+
+        it('reconstruct contact given ContactQR JSON', () => {
+            // Arrange:
+            const account = PublicAccount.createFromPublicKey(
+                'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
+                NetworkType.TEST_NET
+            );
+
+            // Act:
+            const exportContact = new ContactQR('nemtech', account, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const importContact = ContactQR.fromJSON(exportContact.toJSON());
+
+            // Assert
+            expect(importContact.name).to.be.equal('nemtech');
+            expect(importContact.account.publicKey).to.be.equal(exportContact.account.publicKey);
+        });
+
+        it('reconstruct contact given correct JSON structure', () => {
+            // Arrange:
+            const contactInfo = {
+                v: 3,
+                type: QRCodeType.AddContact,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    name: 'nemtech',
+                    publicKey: 'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268'
+                }
+            };
+
+            // Act:
+            const importContact = ContactQR.fromJSON(JSON.stringify(contactInfo));
+
+            // Assert
+            expect(importContact.name).to.be.equal('nemtech');
+            expect(importContact.account.publicKey).to.be.equal('C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268');
+        });
+
     });
 
 });

--- a/test/CosignatureQR.spec.ts
+++ b/test/CosignatureQR.spec.ts
@@ -26,16 +26,36 @@ import {
     NetworkType,
     PublicAccount,
 } from 'nem2-sdk';
-import {
-    QRCode as QRCodeImpl,
-    QR8BitByte,
-    ErrorCorrectLevel,
-} from 'qrcode-generator-ts';
 
 // internal dependencies
 import {
     CosignatureQR,
+    QRCodeType,
 } from "../index";
+
+const bondedCreationHelper = () => {
+    const account = PublicAccount.createFromPublicKey(
+        'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
+        NetworkType.MIJIN_TEST
+    );
+    const transfer = TransferTransaction.create(
+        Deadline.create(1),
+        Address.createFromPublicKey(
+            'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
+            NetworkType.MIJIN_TEST
+        ),
+        [new Mosaic(new NamespaceId('cat.currency'), UInt64.fromUint(10000000))],
+        PlainMessage.create('Welcome to NEM!'),
+        NetworkType.MIJIN_TEST
+    );
+    const bonded = AggregateTransaction.createBonded(
+        Deadline.create(1),
+        [transfer.toAggregate(account)],
+        NetworkType.MIJIN_TEST
+    );
+
+    return bonded;
+};
 
 describe('CosignatureQR -->', () => {
 
@@ -43,25 +63,7 @@ describe('CosignatureQR -->', () => {
 
         it('include mandatory NIP-7 QR Code base fields', () => {
             // Arrange:
-            const account = PublicAccount.createFromPublicKey(
-                'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
-                NetworkType.MIJIN_TEST
-            );
-            const transfer = TransferTransaction.create(
-                Deadline.create(),
-                Address.createFromPublicKey(
-                    'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
-                    NetworkType.MIJIN_TEST
-                ),
-                [new Mosaic(new NamespaceId('cat.currency'), UInt64.fromUint(10000000))],
-                PlainMessage.create('Welcome to NEM!'),
-                NetworkType.MIJIN_TEST
-            );
-            const bonded = AggregateTransaction.createBonded(
-                Deadline.create(),
-                [transfer.toAggregate(account)],
-                NetworkType.MIJIN_TEST
-            );
+            const bonded = bondedCreationHelper();
 
             // Act:
             const requestTx = new CosignatureQR(bonded, NetworkType.TEST_NET, '');
@@ -78,25 +80,7 @@ describe('CosignatureQR -->', () => {
 
         it('include specialized schema fields', () => {
             // Arrange:
-            const account = PublicAccount.createFromPublicKey(
-                'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
-                NetworkType.MIJIN_TEST
-            );
-            const transfer = TransferTransaction.create(
-                Deadline.create(),
-                Address.createFromPublicKey(
-                    'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268',
-                    NetworkType.MIJIN_TEST
-                ),
-                [new Mosaic(new NamespaceId('cat.currency'), UInt64.fromUint(10000000))],
-                PlainMessage.create('Welcome to NEM!'),
-                NetworkType.MIJIN_TEST
-            );
-            const bonded = AggregateTransaction.createBonded(
-                Deadline.create(),
-                [transfer.toAggregate(account)],
-                NetworkType.MIJIN_TEST
-            );
+            const bonded = bondedCreationHelper();
 
             // Act:
             const requestTx = new CosignatureQR(bonded, NetworkType.TEST_NET, '');
@@ -106,6 +90,47 @@ describe('CosignatureQR -->', () => {
             // Assert:
             expect(actualObject.data).to.have.property('payload');
         });
+    });
+
+    describe('fromJSON() should', () => {
+
+        it('reconstruct aggregate bonded given CosignatureQR JSON', () => {
+            // Arrange:
+            const bonded = bondedCreationHelper();
+
+            // Act:
+            const exportCosig = new CosignatureQR(bonded, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const importCosig = CosignatureQR.fromJSON(exportCosig.toJSON());
+
+            // Assert
+            expect(importCosig.transaction.serialize()).to.be.equal(exportCosig.transaction.serialize());
+        });
+
+        it('reconstruct aggregate bonded given correct JSON structure', () => {
+            // Arrange:
+            const cosigInfo = {
+                v: 3,
+                type: QRCodeType.RequestCosignature,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    payload: 'E000000000000000000000000000000000000000000000000000000000000000'
+                           + '0000000000000000000000000000000000000000000000000000000000000000'
+                           + '0000000000000000000000000000000000000000000000000000000000000000'
+                           + '0000000001904142000000000000000025A52B4E190000006400000064000000'
+                           + 'C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268'
+                           + '019054419051F5B062FE3931B29B095AB8FD42FCC2010AE1A67D903BC5100001'
+                           + '0057656C636F6D6520746F204E454D2144B262C46CEABB858096980000000000'
+                }
+            };
+
+            // Act:
+            const importCosig = CosignatureQR.fromJSON(JSON.stringify(cosigInfo));
+
+            // Assert:
+            expect(importCosig.transaction.serialize()).to.be.equal(cosigInfo.data.payload);
+        });
+
     });
 
 });

--- a/test/MnemonicQR.spec.ts
+++ b/test/MnemonicQR.spec.ts
@@ -82,6 +82,26 @@ describe('MnemonicQR -->', () => {
             })).to.throw('Could not parse encrypted mnemonic pass phrase.');
         });
 
+        it('throw error given encrypted payload is invalid', () => {
+            // Arrange:
+            let accountInfo:any = {
+                v: 3,
+                type: QRCodeType.ExportMnemonic,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    // 'ciphertext' field for encrypted payload missing
+                    salt: "b248953e9ebfa269cd7b940f9c03d2d4b192f90db61638375b5e78296bbe675a"
+                }
+            };
+            const password = new Password('password');
+
+            // Act + Assert
+            expect((function () {
+                const importAccount = MnemonicQR.fromJSON(JSON.stringify(accountInfo), password);
+            })).to.throw('Could not parse encrypted mnemonic pass phrase.');
+        });
+
         it('reconstruct mnemonic pass phrase given correct password', () => {
             // Arrange:
             const mnemonic = MnemonicPassPhrase.createRandom();

--- a/test/MnemonicQR.spec.ts
+++ b/test/MnemonicQR.spec.ts
@@ -24,6 +24,7 @@ import { MnemonicPassPhrase } from 'nem2-hd-wallets';
 // internal dependencies
 import {
     MnemonicQR,
+    QRCodeType,
 } from "../index";
 
 describe('MnemonicQR -->', () => {
@@ -64,7 +65,7 @@ describe('MnemonicQR -->', () => {
         });
     });
 
-    describe('fromJSON should', () => {
+    describe('fromJSON() should', () => {
 
         it('throw error given wrong password', () => {
             // Arrange:
@@ -78,7 +79,7 @@ describe('MnemonicQR -->', () => {
             // Act + Assert
             expect((function () {
                 const importMnemonic = MnemonicQR.fromJSON(exportMnemonic.toJSON(), wrongPw);
-            })).to.throw('Invalid password.');
+            })).to.throw('Could not parse encrypted mnemonic pass phrase.');
         });
 
         it('reconstruct mnemonic pass phrase given correct password', () => {
@@ -92,6 +93,34 @@ describe('MnemonicQR -->', () => {
 
             // Assert
             expect(importMnemonic.mnemonic.plain).to.be.equal(mnemonic.plain);
+        });
+
+        it('reconstruct mnemonic pass phrase given correct ciphertext and password', () => {
+            // Arrange:
+            const mnemonicInfo = {
+                v: 3,
+                type: QRCodeType.ExportMnemonic,
+                network_id: NetworkType.MIJIN_TEST,
+                chain_id: "9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7",
+                data: {
+                    ciphertext: "964322228f401a2ec576ac256cbbdce29YfW+CykqESzGSzDYuKJxJUSpQ4woqMdD8Up7mjbow09I/UYV4e8HEgbhjlLjf30YLlQ+JKLBTf9kUGMnp3tZqYSq3lLZRDp8TVE6GzHiX4V59RTP7BOixwpDWDmfOP0B0i+Q1s0+OPfmyck4p7YZkVNi/HYvQF4kDV27sjRTZKs+uETKA0Ae0rl17d9EMV3eLUVcWEGE/ChgEfmnMlN1g==",
+                    salt: "b248953e9ebfa269cd7b940f9c03d2d4b192f90db61638375b5e78296bbe675a"
+                }
+            };
+            const password = new Password('password');
+
+            // Act:
+            const importMnemonic = MnemonicQR.fromJSON(JSON.stringify(mnemonicInfo), password);
+
+            // Assert
+            expect(importMnemonic.mnemonic.plain).to.be.equal(
+                'stumble shoot spawn bitter '
+              + 'forest waste attitude chest ' 
+              + 'square kite dawn photo '
+              + 'twice message bargain trap '
+              + 'spin vote lamp wire '
+              + 'also either else pupil'
+            );
         });
     });
 

--- a/test/MnemonicQR.spec.ts
+++ b/test/MnemonicQR.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+import {expect} from "chai";
+import {
+    Account,
+    NetworkType,
+    Password,
+} from 'nem2-sdk';
+import { MnemonicPassPhrase } from 'nem2-hd-wallets';
+
+// internal dependencies
+import {
+    MnemonicQR,
+} from "../index";
+
+describe('MnemonicQR -->', () => {
+
+    describe('toJSON() should', () => {
+
+        it('include mandatory NIP-7 QR Code base fields', () => {
+            // Arrange:
+            const mnemonic = MnemonicPassPhrase.createRandom();
+            const password = new Password('password');
+
+            // Act:
+            const exportMnemonic = new MnemonicQR(mnemonic, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const actualJSON = exportMnemonic.toJSON();
+            const actualObject = JSON.parse(actualJSON);
+
+            // Assert:
+            expect(actualObject).to.have.property('v');
+            expect(actualObject).to.have.property('type');
+            expect(actualObject).to.have.property('network_id');
+            expect(actualObject).to.have.property('chain_id');
+            expect(actualObject).to.have.property('data');
+        });
+
+        it('include specialized schema fields', () => {
+            // Arrange:
+            const mnemonic = MnemonicPassPhrase.createRandom();
+            const password = new Password('password');
+
+            // Act:
+            const exportMnemonic = new MnemonicQR(mnemonic, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const actualJSON = exportMnemonic.toJSON();
+            const actualObject = JSON.parse(actualJSON);
+
+            // Assert:
+            expect(actualObject.data).to.have.property('ciphertext');
+            expect(actualObject.data).to.have.property('salt');
+        });
+    });
+
+    describe('fromJSON should', () => {
+
+        it('throw error given wrong password', () => {
+            // Arrange:
+            const mnemonic = MnemonicPassPhrase.createRandom();
+            const password = new Password('password');
+            const wrongPw  = new Password('passw0rd');
+
+            // Act:
+            const exportMnemonic = new MnemonicQR(mnemonic, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+
+            // Act + Assert
+            expect((function () {
+                const importMnemonic = MnemonicQR.fromJSON(exportMnemonic.toJSON(), wrongPw);
+            })).to.throw('Invalid password.');
+        });
+
+        it('reconstruct mnemonic pass phrase given correct password', () => {
+            // Arrange:
+            const mnemonic = MnemonicPassPhrase.createRandom();
+            const password = new Password('password');
+
+            // Act:
+            const exportMnemonic = new MnemonicQR(mnemonic, password, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const importMnemonic = MnemonicQR.fromJSON(exportMnemonic.toJSON(), password);
+
+            // Assert
+            expect(importMnemonic.mnemonic.plain).to.be.equal(mnemonic.plain);
+        });
+    });
+
+});

--- a/test/QRCode.spec.ts
+++ b/test/QRCode.spec.ts
@@ -39,8 +39,8 @@ class FakeQR extends QRCode implements QRCodeInterface {
     constructor(
         public readonly object: Object,
         public readonly networkType: NetworkType,
-        public readonly chainId: string) {
-        super(QRCodeType.ExportObject, networkType, chainId);
+        public readonly generationHash: string) {
+        super(QRCodeType.ExportObject, networkType, generationHash);
     }
 
     public getSchema(): QRCodeDataSchema {

--- a/test/QRCodeGenerator.spec.ts
+++ b/test/QRCodeGenerator.spec.ts
@@ -50,8 +50,8 @@ describe('QRCodeGenerator -->', () => {
 
             // Assert:
             expect(objectQR.networkType).to.be.equal(NetworkType.MIJIN_TEST);
-            expect(objectQR.chainId).to.not.be.undefined;
-            expect(objectQR.chainId).to.have.lengthOf(64);
+            expect(objectQR.generationHash).to.not.be.undefined;
+            expect(objectQR.generationHash).to.have.lengthOf(64);
         });
 
         it('fill object property correctly with {test: test}', () => {

--- a/test/QRCodeGenerator.spec.ts
+++ b/test/QRCodeGenerator.spec.ts
@@ -96,7 +96,7 @@ describe('QRCodeGenerator -->', () => {
 
     describe('createAddContact() should', () => {
 
-        it('generate correct Base64 representation for TransferTransaction', () => {
+        it('generate correct Base64 representation for AddContact', () => {
             // Arrange:
             const name = 'test-contact-1';
             const account = PublicAccount.createFromPublicKey(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,7 @@
   ],
   "include": [
     "test/*.spec.ts",
-    "src/*.ts"
+    "src/*.ts",
+    "examples/*.ts"
   ]
 }


### PR DESCRIPTION
### Added

- Added `MnemonicQR` and `ExportMnemonicDataSchema` to create QR codes containing password encrypted mnemonic pass phrase.
- Added encoders/ to deal with different encoding practices, currently only supports ASCII, Canvas and Base64.
- Added examples/ with WIP on browser/client-side integration.

### Fixed

- Fixed AccountQR size to version 15, added MnemonicQR to encrypt mnemonic pass phrases.
- Fixed ASCII encoding and refactored to encoders/.
- Renamed `chainId` to `generationHash` for consistency with protocol.
- Upgraded dependencies including `qrcode` and `typescript`.
